### PR TITLE
Add GitHub Actions workflow to build and push Docker image to Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,6 @@ coverage
 .nyc_output
 dist
 build
+
+# Tests
+__tests__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
           context: .
           push: false
           tags: express-hello:latest
-          load: true  
+          platforms: linux/amd64,linux/arm64
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -59,3 +60,46 @@ jobs:
           curl -f http://localhost:3500/health || exit 1
           docker stop test-container
           docker rm test-container
+
+  push-to-docker-hub:
+    runs-on: ubuntu-latest
+    needs: test-and-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      # Checkout code
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up Docker BuildX
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v3
+
+      # Login to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Extract meta-data for tags
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/express-hello
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix={{branch}}-
+
+      # Build and push to Docker Hub
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           push: false
           tags: express-hello:latest
           platforms: linux/amd64
-          load: true
+          # load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           context: .
           push: false
           tags: express-hello:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           push: false
           tags: express-hello:latest
           platforms: linux/amd64
-          # load: true
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This PR introduces a GitHub Actions job that:

- Builds the Docker image for multi-platforms (amd64 & arm64)
- Pushes the image to Docker Hub automatically on main branch push
- Uses Docker Hub credentials stored in GitHub Secrets
- Ensures the image is tested locally before push